### PR TITLE
fix: Allows building on Mac OS

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -8,7 +8,7 @@ int main(int argc, char** agrv)
     qdcsg::mesh A;
     qdcsg::mesh B;
 
-    std::shared_ptr<qdcsg::mesh> AdiffB = qdcsg::difference(A, B);
+    std::shared_ptr<qdcsg::mesh> AdiffB = qdcsg::Difference(A, B);
 
 
 

--- a/qdcsg.hpp
+++ b/qdcsg.hpp
@@ -31,8 +31,8 @@
 #include <list>
 #include <memory>
 #include <vector>
-#include <string>
 #include <cmath>
+#include <stdexcept>
 
 namespace qdcsg
 {
@@ -159,7 +159,7 @@ namespace qdcsg
                 float s = dot(subtract(pP, rP), pN) / dotrDpN;
                 return vertex(rP.x_ + (rD.x_ * s), rP.y_ + (rD.y_ * s), rP.z_ + (rD.z_ * s));
             }
-            throw std::string("RayAndPlaneNormalAreParrallel");
+            throw std::runtime_error("RayAndPlaneNormalAreParrallel");
         }
 
         class bspTree
@@ -193,7 +193,7 @@ namespace qdcsg
 
                     // vertices should already be present in tree... these are added upon construction...
                     if (std::isnan(normal_.x_) || std::isnan(normal_.y_) || std::isnan(normal_.z_))
-                        throw std::string("BSPTreeNodeUnableToConstruct");
+                        throw std::runtime_error("BSPTreeNodeUnableToConstruct");
                 }
 
                 std::unique_ptr<node> inside_;
@@ -617,7 +617,7 @@ namespace qdcsg
                         }
                     }
                     else
-                        throw std::string("CSGSplitInvalid");
+                        throw std::runtime_error("CSGSplitInvalid");
 
                     if (validateTriangle(insideTriangle, output->vertices_[insideTriangle.a_], output->vertices_[insideTriangle.b_], output->vertices_[insideTriangle.c_]))
                         output->insideTriangles_.push_back(insideTriangle);

--- a/qdcsg.hpp
+++ b/qdcsg.hpp
@@ -31,6 +31,8 @@
 #include <list>
 #include <memory>
 #include <vector>
+#include <string>
+#include <cmath>
 
 namespace qdcsg
 {
@@ -157,7 +159,7 @@ namespace qdcsg
                 float s = dot(subtract(pP, rP), pN) / dotrDpN;
                 return vertex(rP.x_ + (rD.x_ * s), rP.y_ + (rD.y_ * s), rP.z_ + (rD.z_ * s));
             }
-            throw std::exception("RayAndPlaneNormalAreParrallel");
+            throw std::string("RayAndPlaneNormalAreParrallel");
         }
 
         class bspTree
@@ -191,7 +193,7 @@ namespace qdcsg
 
                     // vertices should already be present in tree... these are added upon construction...
                     if (std::isnan(normal_.x_) || std::isnan(normal_.y_) || std::isnan(normal_.z_))
-                        throw std::exception("BSPTreeNodeUnableToConstruct");
+                        throw std::string("BSPTreeNodeUnableToConstruct");
                 }
 
                 std::unique_ptr<node> inside_;
@@ -615,7 +617,7 @@ namespace qdcsg
                         }
                     }
                     else
-                        throw std::exception("CSGSplitInvalid");
+                        throw std::string("CSGSplitInvalid");
 
                     if (validateTriangle(insideTriangle, output->vertices_[insideTriangle.a_], output->vertices_[insideTriangle.b_], output->vertices_[insideTriangle.c_]))
                         output->insideTriangles_.push_back(insideTriangle);


### PR DESCRIPTION
With this compiler, 
>Apple clang version 12.0.0 (clang-1200.0.32.29)
>Target: x86_64-apple-darwin19.6.0

It did not build out of the box. So, I  changed to throw std::string, as std::exception doesn't have a string constructor. I think this is the proper way.
Also included cmath header for std::isnan